### PR TITLE
Support more than one alias in last_file mode

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16215,18 +16215,19 @@ function identify_reviewers_by_changed_files({ config, changed_files, excludes =
     return [];
   }
 
-  const matching_reviewers = [];
+  const matching_reviewers = {};
 
   Object.entries(config.files).forEach(([ glob_pattern, reviewers ]) => {
-    if (changed_files.some((changed_file) => minimatch(changed_file, glob_pattern))) {
+    changed_files.filter((changed_file) => minimatch(changed_file, glob_pattern)).forEach((changed_file) => {
+      matching_reviewers[changed_file] ??= []
       if (last_files_match_only) {
-        matching_reviewers.length = 0; // clear previous matches
+        matching_reviewers[changed_file].length = 0; // clear previous matches
       }
-      matching_reviewers.push(...reviewers);
-    }
+      matching_reviewers[changed_file].push(...reviewers);
+    });
   });
 
-  const individuals = replace_groups_with_individuals({ reviewers: matching_reviewers, config });
+  const individuals = replace_groups_with_individuals({ reviewers: Object.values(matching_reviewers).flat(), config });
 
   // Depue and filter the results
   return [ ...new Set(individuals) ].filter((reviewer) => !excludes.includes(reviewer));

--- a/src/reviewer.js
+++ b/src/reviewer.js
@@ -48,18 +48,19 @@ function identify_reviewers_by_changed_files({ config, changed_files, excludes =
     return [];
   }
 
-  const matching_reviewers = [];
+  const matching_reviewers = {};
 
   Object.entries(config.files).forEach(([ glob_pattern, reviewers ]) => {
-    if (changed_files.some((changed_file) => minimatch(changed_file, glob_pattern))) {
+    changed_files.filter((changed_file) => minimatch(changed_file, glob_pattern)).forEach((changed_file) => {
+      matching_reviewers[changed_file] ??= []
       if (last_files_match_only) {
-        matching_reviewers.length = 0; // clear previous matches
+        matching_reviewers[changed_file].length = 0; // clear previous matches
       }
-      matching_reviewers.push(...reviewers);
-    }
+      matching_reviewers[changed_file].push(...reviewers);
+    });
   });
 
-  const individuals = replace_groups_with_individuals({ reviewers: matching_reviewers, config });
+  const individuals = replace_groups_with_individuals({ reviewers: Object.values(matching_reviewers).flat(), config });
 
   // Depue and filter the results
   return [ ...new Set(individuals) ].filter((reviewer) => !excludes.includes(reviewer));

--- a/test/reviewer.test.js
+++ b/test/reviewer.test.js
@@ -126,6 +126,28 @@ describe('reviewer', function() {
       };
       expect(identify_reviewers_by_changed_files({ config: config_with_last_files_match_only, changed_files })).to.have.members([ 'mario', 'someone-specific' ]);
     });
+
+    it('assigns aliases to different files with custom groups - `last_files_match_only` `true` (CODEWONERS-compatible)', function() {
+      const changed_files = [ 'backend/some-specific-file', 'frontend/path/to/file' ];
+      const config_with_last_files_match_only = {
+        ...config,
+        options: {
+          last_files_match_only: true,
+        },
+      };
+      expect(identify_reviewers_by_changed_files({ config: config_with_last_files_match_only, changed_files })).to.have.members([ 'mario', 'someone-specific', 'princess-peach', 'toad' ]);
+    });
+
+    it('assigns aliases to different files with aliases - `last_files_match_only` `true` (CODEWONERS-compatible)', function() {
+      const changed_files = [ 'backend/some-specific-file', 'super-star' ];
+      const config_with_last_files_match_only = {
+        ...config,
+        options: {
+          last_files_match_only: true,
+        },
+      };
+      expect(identify_reviewers_by_changed_files({ config: config_with_last_files_match_only, changed_files })).to.have.members([ 'mario', 'someone-specific', 'luigi' ]);
+    });
   });
 
   describe('identify_reviewers_by_author()', function() {


### PR DESCRIPTION
There is an open issue with the upstream repo (https://github.com/necojackarc/auto-request-review/issues/115) where the behavior when turning on `last_files_match_only` only matches one alias, even if mutliple files have been edited.

This is a different behavior than GitHub's codeowners file which the setting seeks to emulate. 

This PR adds a per file check to the last match, allowing each file to add one alias assuming that that file matches a glob pattern inside the codereviewers yaml file. 