### PR TITLE
Skip Re-Assigning Aliases to PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16174,7 +16174,7 @@ async function run() {
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });
 
-  if (reviewers.length) {
+  if (reviewers.length > 0) {
     core.info(`Requesting review to ${reviewers.join(', ')}`);
     await github.assign_reviewers(reviewers);
   } else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -16013,11 +16013,11 @@ async function fetch_current_reviewers() {
   const { data: response_body } = await octokit.pulls.listRequestedReviewers({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: context.payload.pull_request.number
+    pull_number: context.payload.pull_request.number,
   });
 
-  current_reviewers.push(...response_body['users'].map((user) => user.login));
-  current_reviewers.push(...response_body['teams'].map((team) => "team:".concat(team.slug)));
+  current_reviewers.push(...response_body.users.map((user) => user.login));
+  current_reviewers.push(...response_body.teams.map((team) => 'team:'.concat(team.slug)));
 
   return current_reviewers;
 }
@@ -16140,7 +16140,7 @@ async function run() {
   core.info('Fetching changed files in the pull request');
   const changed_files = await github.fetch_changed_files();
 
-  core.info('Fetching currently requested reviewers')
+  core.info('Fetching currently requested reviewers');
   const current_reviewers = await github.fetch_current_reviewers();
   core.info(`Already in review: ${current_reviewers.join(', ')}`);
 
@@ -16168,7 +16168,7 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
-  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers`)
+  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers`);
   reviewers = reviewers.filter((reviewer) => !current_reviewers.includes(reviewer));
 
   core.info('Randomly picking reviewers if the number of reviewers is set');

--- a/dist/index.js
+++ b/dist/index.js
@@ -16001,6 +16001,27 @@ async function fetch_changed_files() {
   return changed_files;
 }
 
+async function fetch_current_reviewers() {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  const current_reviewers = [];
+
+  // API docs
+  // Generated octokit methods: https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/main/src/generated/endpoints.ts
+  // Available Rest APIs: https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#get-all-requested-reviewers-for-a-pull-request
+  const { data: response_body } = await octokit.pulls.listRequestedReviewers({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number
+  });
+
+  current_reviewers.push(...response_body['users'].map((user) => user.login));
+  current_reviewers.push(...response_body['teams'].map((team) => "team:".concat(team.slug)));
+
+  return current_reviewers;
+}
+
 async function assign_reviewers(reviewers) {
   const context = get_context();
   const octokit = get_octokit();
@@ -16061,6 +16082,7 @@ module.exports = {
   get_pull_request,
   fetch_config,
   fetch_changed_files,
+  fetch_current_reviewers,
   assign_reviewers,
   clear_cache,
 };
@@ -16117,6 +16139,10 @@ async function run() {
 
   core.info('Fetching changed files in the pull request');
   const changed_files = await github.fetch_changed_files();
+
+  core.info('Fetching currently requested reviewers')
+  const current_reviewers = await github.fetch_current_reviewers();
+  core.info(`Already in review: ${current_reviewers.join(', ')}`);
 
   core.info('Identifying reviewers based on the changed files');
   const reviewers_based_on_files = identify_reviewers_by_changed_files({ config, changed_files, excludes: [ author ] });

--- a/dist/index.js
+++ b/dist/index.js
@@ -16174,8 +16174,12 @@ async function run() {
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });
 
-  core.info(`Requesting review to ${reviewers.join(', ')}`);
-  await github.assign_reviewers(reviewers);
+  if (reviewers.length) {
+    core.info(`Requesting review to ${reviewers.join(', ')}`);
+    await github.assign_reviewers(reviewers);
+  } else {
+    core.info('No new reviewers to assign to PR');
+  }
 }
 
 module.exports = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -16168,6 +16168,9 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
+  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers`)
+  reviewers = reviewers.filter((reviewer) => !current_reviewers.includes(reviewer));
+
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });
 

--- a/src/github.js
+++ b/src/github.js
@@ -108,11 +108,11 @@ async function fetch_current_reviewers() {
   const { data: response_body } = await octokit.pulls.listRequestedReviewers({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: context.payload.pull_request.number
+    pull_number: context.payload.pull_request.number,
   });
 
-  current_reviewers.push(...response_body['users'].map((user) => user.login));
-  current_reviewers.push(...response_body['teams'].map((team) => "team:".concat(team.slug)));
+  current_reviewers.push(...response_body.users.map((user) => user.login));
+  current_reviewers.push(...response_body.teams.map((team) => 'team:'.concat(team.slug)));
 
   return current_reviewers;
 }

--- a/src/github.js
+++ b/src/github.js
@@ -96,6 +96,27 @@ async function fetch_changed_files() {
   return changed_files;
 }
 
+async function fetch_current_reviewers() {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  const current_reviewers = [];
+
+  // API docs
+  // Generated octokit methods: https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/main/src/generated/endpoints.ts
+  // Available Rest APIs: https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#get-all-requested-reviewers-for-a-pull-request
+  const { data: response_body } = await octokit.pulls.listRequestedReviewers({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number
+  });
+
+  current_reviewers.push(...response_body['users'].map((user) => user.login));
+  current_reviewers.push(...response_body['teams'].map((team) => "team:".concat(team.slug)));
+
+  return current_reviewers;
+}
+
 async function assign_reviewers(reviewers) {
   const context = get_context();
   const octokit = get_octokit();
@@ -156,6 +177,7 @@ module.exports = {
   get_pull_request,
   fetch_config,
   fetch_changed_files,
+  fetch_current_reviewers,
   assign_reviewers,
   clear_cache,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,10 @@ async function run() {
   core.info('Fetching changed files in the pull request');
   const changed_files = await github.fetch_changed_files();
 
+  core.info('Fetching currently requested reviewers')
+  const current_reviewers = await github.fetch_current_reviewers();
+  core.info(`Already in review: ${current_reviewers.join(', ')}`);
+
   core.info('Identifying reviewers based on the changed files');
   const reviewers_based_on_files = identify_reviewers_by_changed_files({ config, changed_files, excludes: [ author ] });
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,12 @@ async function run() {
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });
 
-  core.info(`Requesting review to ${reviewers.join(', ')}`);
-  await github.assign_reviewers(reviewers);
+  if (reviewers.length) {
+    core.info(`Requesting review to ${reviewers.join(', ')}`);
+    await github.assign_reviewers(reviewers);
+  } else {
+    core.info('No new reviewers to assign to PR');
+  }
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,9 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
+  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers`)
+  reviewers = reviewers.filter((reviewer) => !current_reviewers.includes(reviewer));
+
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ async function run() {
   core.info('Fetching changed files in the pull request');
   const changed_files = await github.fetch_changed_files();
 
-  core.info('Fetching currently requested reviewers')
+  core.info('Fetching currently requested reviewers');
   const current_reviewers = await github.fetch_current_reviewers();
   core.info(`Already in review: ${current_reviewers.join(', ')}`);
 
@@ -72,7 +72,7 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
-  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers`)
+  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers`);
   reviewers = reviewers.filter((reviewer) => !current_reviewers.includes(reviewer));
 
   core.info('Randomly picking reviewers if the number of reviewers is set');

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ async function run() {
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });
 
-  if (reviewers.length) {
+  if (reviewers.length > 0) {
     core.info(`Requesting review to ${reviewers.join(', ')}`);
     await github.assign_reviewers(reviewers);
   } else {

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -136,7 +136,7 @@ describe('github', function() {
       github.getOctokit.returns(octokit);
     });
 
-    it('fetch current reviewers - user only', async function() {
+    it('fetches current reviewers - user only', async function() {
       stub.returns({
         data: {
           users: [

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -150,7 +150,7 @@ describe('github', function() {
       expect(actual).to.deep.equal(expected);
     });
 
-    it('fetch current reviewers - team only', async function() {
+    it('fetches current reviewers - team only', async function() {
       stub.returns({
         data: {
           users: [ ],
@@ -164,7 +164,7 @@ describe('github', function() {
       expect(actual).to.deep.equal(expected);
     });
 
-    it('fetch current reviewers - combined users and teams', async function() {
+    it('fetches current reviewers - combined users and teams', async function() {
       stub.returns({
         data: {
           users: [

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -140,9 +140,9 @@ describe('github', function() {
       stub.returns({
         data: {
           users: [
-            { login: 'super/mario/64' }
+            { login: 'super/mario/64' },
           ],
-          teams: []
+          teams: [],
         },
       });
       const expected = [ 'super/mario/64' ];
@@ -155,8 +155,8 @@ describe('github', function() {
         data: {
           users: [ ],
           teams: [
-            { slug: 'super_marios'}
-          ]
+            { slug: 'super_marios' },
+          ],
         },
       });
       const expected = [ 'team:super_marios' ];
@@ -167,15 +167,15 @@ describe('github', function() {
     it('fetch current reviewers - combined users and teams', async function() {
       stub.returns({
         data: {
-          users: [ 
-            { login: 'bowser'},
+          users: [
+            { login: 'bowser' },
             { login: 'peach' },
             { login: 'luigi' },
           ],
           teams: [
-            { slug: 'super_marios'},
-            { slug: 'toads'},
-          ]
+            { slug: 'super_marios' },
+            { slug: 'toads' },
+          ],
         },
       });
       const expected = [ 'bowser', 'peach', 'luigi', 'team:super_marios', 'team:toads' ];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,7 +85,7 @@ describe('index', function() {
       const changed_files = [ 'path/to/file.js' ];
       github.fetch_changed_files.returns(changed_files);
 
-      const current_reviewers = ['princess-peach'];
+      const current_reviewers = [ 'princess-peach' ];
       github.fetch_current_reviewers.returns(current_reviewers);
 
       await run();
@@ -119,7 +119,7 @@ describe('index', function() {
       const changed_files = [ 'path/to/file.js', 'path/to/file.rb' ];
       github.fetch_changed_files.returns(changed_files);
 
-      const current_reviewers = ['team:bowser-and-co'];
+      const current_reviewers = [ 'team:bowser-and-co' ];
       github.fetch_current_reviewers.returns(current_reviewers);
 
       await run();
@@ -153,7 +153,7 @@ describe('index', function() {
       const changed_files = [ 'path/to/file.js' ];
       github.fetch_changed_files.returns(changed_files);
 
-      const current_reviewers = ['princess-peach', 'mario'];
+      const current_reviewers = [ 'princess-peach', 'mario' ];
       github.fetch_current_reviewers.returns(current_reviewers);
 
       await run();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,7 @@ describe('index', function() {
       sinon.stub(github, 'get_pull_request');
       sinon.stub(github, 'fetch_config');
       sinon.stub(github, 'fetch_changed_files');
+      sinon.stub(github, 'fetch_current_reviewers');
       sinon.stub(github, 'assign_reviewers');
     });
 
@@ -21,6 +22,7 @@ describe('index', function() {
       github.get_pull_request.restore();
       github.fetch_config.restore();
       github.fetch_changed_files.restore();
+      github.fetch_current_reviewers.restore();
       github.assign_reviewers.restore();
     });
 
@@ -48,6 +50,9 @@ describe('index', function() {
 
       const changed_fiels = [ 'path/to/file.js' ];
       github.fetch_changed_files.returns(changed_fiels);
+
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
 
       await run();
 
@@ -80,6 +85,9 @@ describe('index', function() {
       const changed_fiels = [];
       github.fetch_changed_files.returns(changed_fiels);
 
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
+
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
@@ -107,6 +115,9 @@ describe('index', function() {
       const changed_fiels = [ 'path/to/file.js' ];
       github.fetch_changed_files.returns(changed_fiels);
 
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
+
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.false;
@@ -132,6 +143,9 @@ describe('index', function() {
 
       const changed_fiels = [ 'path/to/file.js' ];
       github.fetch_changed_files.returns(changed_fiels);
+
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
 
       await run();
 
@@ -162,6 +176,9 @@ describe('index', function() {
       const changed_fiels = [ 'path/to/file.py' ];
       github.fetch_changed_files.returns(changed_fiels);
 
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
+
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.false;
@@ -191,6 +208,9 @@ describe('index', function() {
 
       const changed_fiels = [ 'path/to/file.py' ];
       github.fetch_changed_files.returns(changed_fiels);
+
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
 
       await run();
 
@@ -223,6 +243,9 @@ describe('index', function() {
       const changed_fiels = [];
       github.fetch_changed_files.returns(changed_fiels);
 
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
+
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
@@ -254,6 +277,9 @@ describe('index', function() {
       const changed_fiels = [];
       github.fetch_changed_files.returns(changed_fiels);
 
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
+
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
@@ -282,6 +308,9 @@ describe('index', function() {
 
       const changed_fiels = [];
       github.fetch_changed_files.returns(changed_fiels);
+
+      const current_reviewers = [];
+      github.fetch_current_reviewers.returns(current_reviewers);
 
       await run();
 


### PR DESCRIPTION
In the existing action, the workflow will assign a reviewer regardless of if that reviewer has already been assigned to the pull request: https://github.com/necojackarc/auto-request-review/issues/110

This additionally has the issue of sending extra notifications about being added to a review that you have previously been added to, making it more difficult to manage PR review requests.

To solve this, we add an additional REST call to GH to retrieve the current users that have already been assigned to the PR. We then remove those previously assigned aliases from the list of aliases the workflow will assign.

There is also a slight optimization to not make the PUT REST call to add reviewers if there exists no list of reviewers to add (instead of making the call with no reviewers).