### PR TITLE
Prevent an alias who is not a collaborator from failing to assign any aliases

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17541,7 +17541,7 @@ async function assign_reviewers(reviewers) {
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [ login ],
-    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
+    }).catch((error) => core.error(`Individual: ${login} failed to be added with error: ${error}`)));
   });
 
   return Promise.allSettled(request_review_responses);

--- a/dist/index.js
+++ b/dist/index.js
@@ -17531,7 +17531,7 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      team_reviewers: [ ...team ],
+      team_reviewers: team,
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
 
@@ -17544,7 +17544,6 @@ async function assign_reviewers(reviewers) {
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
 
-  core.info(JSON.stringify(request_review_responses));
   return Promise.all(request_review_responses);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -17522,6 +17522,8 @@ async function assign_reviewers(reviewers) {
   const request_review_responses = [];
 
   // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
+  // Github also does not support a batch call to determine which aliases in the list are not collaborators.
+
   // We therefore make each call individually so that we add all reviewers that are collaborators,
   // and log failure for aliases that no longer have access.
   teams.forEach((team) => {
@@ -17543,8 +17545,7 @@ async function assign_reviewers(reviewers) {
   });
 
   core.info(JSON.stringify(request_review_responses));
-
-  return request_review_responses;
+  return Promise.all(request_review_responses);
 }
 
 /* Private */
@@ -17688,7 +17689,7 @@ async function run() {
 
   if (reviewers.length > 0) {
     core.info(`Requesting review to ${reviewers.join(', ')}`);
-    await Promise.all(github.assign_reviewers(reviewers));
+    await github.assign_reviewers(reviewers);
   } else {
     core.info('No new reviewers to assign to PR');
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -17524,25 +17524,25 @@ async function assign_reviewers(reviewers) {
   // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
   // We therefore make each call individually so that we add all reviewers that are collaborators,
   // and log failure for aliases that no longer have access.
-  request_review_responses.push(...teams.map((team) => {
-    return octokit.pulls.requestReviewers({
+  teams.forEach((team) => {
+    request_review_responses.add(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [],
       team_reviewers: [ ...team ],
-    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`));
-  }));
+    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
+  });
 
-  request_review_responses.push(...individuals.map((login) => {
-    return octokit.pulls.requestReviewers({
+  individuals.forEach((login) => {
+    request_review_responses.add(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [ ...login ],
       team_reviewers: [ ],
-    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`));
-  }));
+    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
+  });
 
   return request_review_responses;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -17529,7 +17529,6 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      reviewers: [],
       team_reviewers: [ ...team ],
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
@@ -17540,9 +17539,10 @@ async function assign_reviewers(reviewers) {
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [ ...login ],
-      team_reviewers: [ ],
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
+
+  core.info(JSON.stringify(request_review_responses));
 
   return request_review_responses;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -17531,7 +17531,7 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      team_reviewers: team,
+      team_reviewers: [ team ],
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
 
@@ -17540,7 +17540,7 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      reviewers: [ ...login ],
+      reviewers: [ login ],
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -17525,7 +17525,7 @@ async function assign_reviewers(reviewers) {
   // We therefore make each call individually so that we add all reviewers that are collaborators,
   // and log failure for aliases that no longer have access.
   teams.forEach((team) => {
-    request_review_responses.add(octokit.pulls.requestReviewers({
+    request_review_responses.push(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
@@ -17535,7 +17535,7 @@ async function assign_reviewers(reviewers) {
   });
 
   individuals.forEach((login) => {
-    request_review_responses.add(octokit.pulls.requestReviewers({
+    request_review_responses.push(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,

--- a/dist/index.js
+++ b/dist/index.js
@@ -17544,7 +17544,7 @@ async function assign_reviewers(reviewers) {
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
 
-  return Promise.all(request_review_responses);
+  return Promise.allSettled(request_review_responses);
 }
 
 /* Private */

--- a/dist/index.js
+++ b/dist/index.js
@@ -17519,13 +17519,32 @@ async function assign_reviewers(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
-  return octokit.pulls.requestReviewers({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    pull_number: context.payload.pull_request.number,
-    reviewers: individuals,
-    team_reviewers: teams,
-  });
+  const request_review_responses = [];
+
+  // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
+  // We therefore make each call individually so that we add all reviewers that are collaborators,
+  // and log failure for aliases that no longer have access.
+  request_review_responses.push(...teams.map((team) => {
+    return octokit.pulls.requestReviewers({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+      reviewers: [],
+      team_reviewers: [ ...team ],
+    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`));
+  }));
+
+  request_review_responses.push(...individuals.map((login) => {
+    return octokit.pulls.requestReviewers({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+      reviewers: [ ...login ],
+      team_reviewers: [ ],
+    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`));
+  }));
+
+  return request_review_responses;
 }
 
 /* Private */
@@ -17669,7 +17688,7 @@ async function run() {
 
   if (reviewers.length > 0) {
     core.info(`Requesting review to ${reviewers.join(', ')}`);
-    await github.assign_reviewers(reviewers);
+    await Promise.all(github.assign_reviewers(reviewers));
   } else {
     core.info('No new reviewers to assign to PR');
   }

--- a/src/github.js
+++ b/src/github.js
@@ -182,7 +182,7 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      team_reviewers: team,
+      team_reviewers: [ team ],
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
 
@@ -191,7 +191,7 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      reviewers: [ ...login ],
+      reviewers: [ login ],
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
 

--- a/src/github.js
+++ b/src/github.js
@@ -176,7 +176,7 @@ async function assign_reviewers(reviewers) {
   // We therefore make each call individually so that we add all reviewers that are collaborators,
   // and log failure for aliases that no longer have access.
   teams.forEach((team) => {
-    request_review_responses.add(octokit.pulls.requestReviewers({
+    request_review_responses.push(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
@@ -186,7 +186,7 @@ async function assign_reviewers(reviewers) {
   });
 
   individuals.forEach((login) => {
-    request_review_responses.add(octokit.pulls.requestReviewers({
+    request_review_responses.push(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,

--- a/src/github.js
+++ b/src/github.js
@@ -175,25 +175,25 @@ async function assign_reviewers(reviewers) {
   // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
   // We therefore make each call individually so that we add all reviewers that are collaborators,
   // and log failure for aliases that no longer have access.
-  request_review_responses.push(...teams.map((team) => {
-    return octokit.pulls.requestReviewers({
+  teams.forEach((team) => {
+    request_review_responses.add(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [],
       team_reviewers: [ ...team ],
-    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`));
-  }));
+    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
+  });
 
-  request_review_responses.push(...individuals.map((login) => {
-    return octokit.pulls.requestReviewers({
+  individuals.forEach((login) => {
+    request_review_responses.add(octokit.pulls.requestReviewers({
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [ ...login ],
       team_reviewers: [ ],
-    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`));
-  }));
+    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
+  });
 
   return request_review_responses;
 }

--- a/src/github.js
+++ b/src/github.js
@@ -173,6 +173,8 @@ async function assign_reviewers(reviewers) {
   const request_review_responses = [];
 
   // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
+  // Github also does not support a batch call to determine which aliases in the list are not collaborators.
+
   // We therefore make each call individually so that we add all reviewers that are collaborators,
   // and log failure for aliases that no longer have access.
   teams.forEach((team) => {
@@ -194,8 +196,7 @@ async function assign_reviewers(reviewers) {
   });
 
   core.info(JSON.stringify(request_review_responses));
-
-  return request_review_responses;
+  return Promise.all(request_review_responses);
 }
 
 /* Private */

--- a/src/github.js
+++ b/src/github.js
@@ -192,7 +192,7 @@ async function assign_reviewers(reviewers) {
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [ login ],
-    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
+    }).catch((error) => core.error(`Individual: ${login} failed to be added with error: ${error}`)));
   });
 
   return Promise.allSettled(request_review_responses);

--- a/src/github.js
+++ b/src/github.js
@@ -170,13 +170,32 @@ async function assign_reviewers(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
-  return octokit.pulls.requestReviewers({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    pull_number: context.payload.pull_request.number,
-    reviewers: individuals,
-    team_reviewers: teams,
-  });
+  const request_review_responses = [];
+
+  // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
+  // We therefore make each call individually so that we add all reviewers that are collaborators,
+  // and log failure for aliases that no longer have access.
+  request_review_responses.push(...teams.map((team) => {
+    return octokit.pulls.requestReviewers({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+      reviewers: [],
+      team_reviewers: [ ...team ],
+    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`));
+  }));
+
+  request_review_responses.push(...individuals.map((login) => {
+    return octokit.pulls.requestReviewers({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: context.payload.pull_request.number,
+      reviewers: [ ...login ],
+      team_reviewers: [ ],
+    }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`));
+  }));
+
+  return request_review_responses;
 }
 
 /* Private */

--- a/src/github.js
+++ b/src/github.js
@@ -195,7 +195,7 @@ async function assign_reviewers(reviewers) {
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
 
-  return Promise.all(request_review_responses);
+  return Promise.allSettled(request_review_responses);
 }
 
 /* Private */

--- a/src/github.js
+++ b/src/github.js
@@ -180,7 +180,6 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      reviewers: [],
       team_reviewers: [ ...team ],
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
@@ -191,9 +190,10 @@ async function assign_reviewers(reviewers) {
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
       reviewers: [ ...login ],
-      team_reviewers: [ ],
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
+
+  core.info(JSON.stringify(request_review_responses));
 
   return request_review_responses;
 }

--- a/src/github.js
+++ b/src/github.js
@@ -182,7 +182,7 @@ async function assign_reviewers(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       pull_number: context.payload.pull_request.number,
-      team_reviewers: [ ...team ],
+      team_reviewers: team,
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
 
@@ -195,7 +195,6 @@ async function assign_reviewers(reviewers) {
     }).catch((error) => core.error(`Individual ${login} failed to be added with error: ${error}`)));
   });
 
-  core.info(JSON.stringify(request_review_responses));
   return Promise.all(request_review_responses);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ async function run() {
 
   if (reviewers.length > 0) {
     core.info(`Requesting review to ${reviewers.join(', ')}`);
-    await Promise.all(github.assign_reviewers(reviewers));
+    await github.assign_reviewers(reviewers);
   } else {
     core.info('No new reviewers to assign to PR');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ async function run() {
 
   if (reviewers.length > 0) {
     core.info(`Requesting review to ${reviewers.join(', ')}`);
-    await github.assign_reviewers(reviewers);
+    await Promise.all(github.assign_reviewers(reviewers));
   } else {
     core.info('No new reviewers to assign to PR');
   }


### PR DESCRIPTION
When the action attempts to assign a list of aliases as reviewers, the batch call will fail if any of the aliases are not a collaborator of the repository and therefore don't have access:

```
HttpError: Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the <owner>/<repo> repository
```

The error does not provide information on which aliases are not collaborators, and the current GH [Rest](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#list-repository-collaborators)/[GraphQL](https://docs.github.com/en/graphql/reference/objects#repository) APIs do not have a "filtered list of collaborators" method. To retrieve collaborator status, we would either need to make an individual network call per alias, or retrieve all collaborators which could be pages of information returned.

The proposed fix is to simplify the approach and update the current rest call to not be a batch call. If a particular alias no longer contains access, the requestReviewers call will print out an error. However, the error will not stop execution (all collaborators get added) and the action will not register as failed. 