### PR TITLE
Prevent Non Collaborator Aliases Version 2: Using Permission API and Batch Call

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17530,7 +17530,7 @@ async function filter_only_collaborators(reviewers) {
     }).then(function(response) {
       core.info(JSON.stringify(response));
       return team;
-    }));
+    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
 
   individuals.forEach((alias) => {
@@ -17541,7 +17541,7 @@ async function filter_only_collaborators(reviewers) {
     }).then(function(response) {
       core.info(JSON.stringify(response));
       return alias;
-    }));
+    }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));
   });
 
   await Promise.allSettled(collaborator_responses);
@@ -17705,7 +17705,7 @@ async function run() {
   // reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
 
   core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
-  reviewers = github.filter_only_collaborators(reviewers);
+  reviewers = await github.filter_only_collaborators(reviewers);
 
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });

--- a/dist/index.js
+++ b/dist/index.js
@@ -17701,8 +17701,8 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
-  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
-  reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
+  // core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
+  // reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
 
   core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
   reviewers = github.filter_only_collaborators(reviewers);

--- a/dist/index.js
+++ b/dist/index.js
@@ -17519,8 +17519,8 @@ async function filter_only_collaborators(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
-  // Create a list of requests for all available aliases to see if they have permission to the
-  // PR associated with this action
+  // Create a list of requests for all available aliases and teams to see if they have permission
+  // to the PR associated with this action
   const collaborator_responses = [];
   teams.forEach((team) => {
     collaborator_responses.push(octokit.teams.checkPermissionsForRepoInOrg({
@@ -17529,8 +17529,8 @@ async function filter_only_collaborators(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
     }).then((response) => {
-      // https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
-      // Its expected that a collaborator with permission will return 204
+      // https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
+      // Its expected that a team with permission will return 204
       core.info(`Received successful status code ${response?.status ?? 'Unknown'} for team: ${team}`);
       return 'team:'.concat(team);
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
@@ -17541,8 +17541,8 @@ async function filter_only_collaborators(reviewers) {
       repo: context.repo.repo,
       username: alias,
     }).then((response) => {
-      // https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
-      // Its expected that a team with permission will return 204
+      // https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
+      // Its expected that a collaborator with permission will return 204
       core.info(`Received successful status code ${response?.status ?? 'Unknown'} for alias: ${alias}`);
       return alias;
     }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));

--- a/dist/index.js
+++ b/dist/index.js
@@ -17519,8 +17519,9 @@ async function filter_only_collaborators(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
+  // Create a list of requests for all available aliases to see if they have permission to the
+  // PR associated with this action
   const collaborator_responses = [];
-
   teams.forEach((team) => {
     collaborator_responses.push(octokit.teams.checkPermissionsForRepoInOrg({
       org: context.repo.owner,
@@ -17528,31 +17529,38 @@ async function filter_only_collaborators(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
     }).then((response) => {
-      core.info(JSON.stringify(response));
-      return team;
+      // https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
+      // Its expected that a collaborator with permission will return 204
+      core.info(`Received successful status code ${response?.status ?? 'Unknown'} for team: ${team}`);
+      return 'team:'.concat(team);
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
-
   individuals.forEach((alias) => {
     collaborator_responses.push(octokit.repos.checkCollaborator({
       owner: context.repo.owner,
       repo: context.repo.repo,
       username: alias,
     }).then((response) => {
-      core.info(JSON.stringify(response));
+      // https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
+      // Its expected that a team with permission will return 204
+      core.info(`Received successful status code ${response?.status ?? 'Unknown'} for alias: ${alias}`);
       return alias;
     }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));
   });
 
+  // Store the aliases and teams of all successful responses
+  const collaborators = [];
   await Promise.allSettled(collaborator_responses).then((results) => {
     results.forEach((result) => {
-      core.info(`foreach: ${result}`)
-      core.info(`foreach: ${JSON.stringify(result)}`)
+      if (result?.value) {
+        collaborators.push(result?.value);
+      }
     });
   });
 
-  core.info(`Filtered list of collabs ${collaborator_responses.join(', ')}`);
-
+  // Only include aliases and teams that exist as collaborators
+  const filtered_reviewers = reviewers.filter((reviewer) => collaborators.includes(reviewer));
+  core.info(`Filtered list of only collaborators ${filtered_reviewers.join(', ')}`);
   return [ ];
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -17512,6 +17512,45 @@ async function fetch_reviewers() {
   return [ ...reviewers ];
 }
 
+async function filter_only_collaborators(reviewers) {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
+  const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
+
+  const collaborator_responses = [];
+
+  teams.forEach((team) => {
+    collaborator_responses.push(octokit.teams.checkPermissionsForRepoInOrg({
+      org: context.repo.owner,
+      team_slug: team,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+    }).then(function(response) {
+      core.info(JSON.stringify(response));
+      return team;
+    }));
+  });
+
+  individuals.forEach((alias) => {
+    collaborator_responses.push(octokit.repos.checkCollaborator({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      username: alias,
+    }).then(function(response) {
+      core.info(JSON.stringify(response));
+      return alias;
+    }));
+  });
+
+  await Promise.allSettled(collaborator_responses);
+
+  core.info(`Filtered list of collabs ${collaborator_responses.join(', ')}`);
+
+  return [ ];
+}
+
 async function assign_reviewers(reviewers) {
   const context = get_context();
   const octokit = get_octokit();
@@ -17576,6 +17615,7 @@ module.exports = {
   fetch_config,
   fetch_changed_files,
   fetch_reviewers,
+  filter_only_collaborators,
   assign_reviewers,
   clear_cache,
 };
@@ -17663,6 +17703,9 @@ async function run() {
 
   core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
   reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
+
+  core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
+  reviewers = github.filter_only_collaborators(reviewers);
 
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });

--- a/dist/index.js
+++ b/dist/index.js
@@ -17519,32 +17519,13 @@ async function assign_reviewers(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
-  const request_review_responses = [];
-
-  // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
-  // Github also does not support a batch call to determine which aliases in the list are not collaborators.
-
-  // We therefore make each call individually so that we add all reviewers that are collaborators,
-  // and log failure for aliases that no longer have access.
-  teams.forEach((team) => {
-    request_review_responses.push(octokit.pulls.requestReviewers({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      pull_number: context.payload.pull_request.number,
-      team_reviewers: [ team ],
-    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
+  return octokit.pulls.requestReviewers({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number,
+    reviewers: individuals,
+    team_reviewers: teams,
   });
-
-  individuals.forEach((login) => {
-    request_review_responses.push(octokit.pulls.requestReviewers({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      pull_number: context.payload.pull_request.number,
-      reviewers: [ login ],
-    }).catch((error) => core.error(`Individual: ${login} failed to be added with error: ${error}`)));
-  });
-
-  return Promise.allSettled(request_review_responses);
 }
 
 /* Private */

--- a/dist/index.js
+++ b/dist/index.js
@@ -17714,8 +17714,8 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
-  // core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
-  // reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
+  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
+  reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
 
   core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
   reviewers = await github.filter_only_collaborators(reviewers);

--- a/dist/index.js
+++ b/dist/index.js
@@ -17527,7 +17527,7 @@ async function filter_only_collaborators(reviewers) {
       team_slug: team,
       owner: context.repo.owner,
       repo: context.repo.repo,
-    }).then(function(response) {
+    }).then((response) => {
       core.info(JSON.stringify(response));
       return team;
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
@@ -17538,13 +17538,18 @@ async function filter_only_collaborators(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       username: alias,
-    }).then(function(response) {
+    }).then((response) => {
       core.info(JSON.stringify(response));
       return alias;
     }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));
   });
 
-  await Promise.allSettled(collaborator_responses);
+  await Promise.allSettled(collaborator_responses).then((results) => {
+    results.forEach((result) => {
+      core.info(`foreach: ${result}`)
+      core.info(`foreach: ${JSON.stringify(result)}`)
+    });
+  });
 
   core.info(`Filtered list of collabs ${collaborator_responses.join(', ')}`);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -17561,7 +17561,7 @@ async function filter_only_collaborators(reviewers) {
   // Only include aliases and teams that exist as collaborators
   const filtered_reviewers = reviewers.filter((reviewer) => collaborators.includes(reviewer));
   core.info(`Filtered list of only collaborators ${filtered_reviewers.join(', ')}`);
-  return [ ];
+  return filtered_reviewers;
 }
 
 async function assign_reviewers(reviewers) {

--- a/src/github.js
+++ b/src/github.js
@@ -178,7 +178,7 @@ async function filter_only_collaborators(reviewers) {
       team_slug: team,
       owner: context.repo.owner,
       repo: context.repo.repo,
-    }).then(function(response) {
+    }).then((response) => {
       core.info(JSON.stringify(response));
       return team;
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
@@ -189,13 +189,18 @@ async function filter_only_collaborators(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       username: alias,
-    }).then(function(response) {
+    }).then((response) => {
       core.info(JSON.stringify(response));
       return alias;
     }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));
   });
 
-  await Promise.allSettled(collaborator_responses);
+  await Promise.allSettled(collaborator_responses).then((results) => {
+    results.forEach((result) => {
+      core.info(`foreach: ${result}`)
+      core.info(`foreach: ${JSON.stringify(result)}`)
+    });
+  });
 
   core.info(`Filtered list of collabs ${collaborator_responses.join(', ')}`);
 

--- a/src/github.js
+++ b/src/github.js
@@ -170,8 +170,8 @@ async function filter_only_collaborators(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
-  // Create a list of requests for all available aliases to see if they have permission to the
-  // PR associated with this action
+  // Create a list of requests for all available aliases and teams to see if they have permission
+  // to the PR associated with this action
   const collaborator_responses = [];
   teams.forEach((team) => {
     collaborator_responses.push(octokit.teams.checkPermissionsForRepoInOrg({
@@ -180,8 +180,8 @@ async function filter_only_collaborators(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
     }).then((response) => {
-      // https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
-      // Its expected that a collaborator with permission will return 204
+      // https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
+      // Its expected that a team with permission will return 204
       core.info(`Received successful status code ${response?.status ?? 'Unknown'} for team: ${team}`);
       return 'team:'.concat(team);
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
@@ -192,8 +192,8 @@ async function filter_only_collaborators(reviewers) {
       repo: context.repo.repo,
       username: alias,
     }).then((response) => {
-      // https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
-      // Its expected that a team with permission will return 204
+      // https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
+      // Its expected that a collaborator with permission will return 204
       core.info(`Received successful status code ${response?.status ?? 'Unknown'} for alias: ${alias}`);
       return alias;
     }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));

--- a/src/github.js
+++ b/src/github.js
@@ -170,8 +170,9 @@ async function filter_only_collaborators(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
+  // Create a list of requests for all available aliases to see if they have permission to the
+  // PR associated with this action
   const collaborator_responses = [];
-
   teams.forEach((team) => {
     collaborator_responses.push(octokit.teams.checkPermissionsForRepoInOrg({
       org: context.repo.owner,
@@ -179,31 +180,38 @@ async function filter_only_collaborators(reviewers) {
       owner: context.repo.owner,
       repo: context.repo.repo,
     }).then((response) => {
-      core.info(JSON.stringify(response));
-      return team;
+      // https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#check-if-a-user-is-a-repository-collaborator
+      // Its expected that a collaborator with permission will return 204
+      core.info(`Received successful status code ${response?.status ?? 'Unknown'} for team: ${team}`);
+      return 'team:'.concat(team);
     }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
-
   individuals.forEach((alias) => {
     collaborator_responses.push(octokit.repos.checkCollaborator({
       owner: context.repo.owner,
       repo: context.repo.repo,
       username: alias,
     }).then((response) => {
-      core.info(JSON.stringify(response));
+      // https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#check-team-permissions-for-a-repository
+      // Its expected that a team with permission will return 204
+      core.info(`Received successful status code ${response?.status ?? 'Unknown'} for alias: ${alias}`);
       return alias;
     }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));
   });
 
+  // Store the aliases and teams of all successful responses
+  const collaborators = [];
   await Promise.allSettled(collaborator_responses).then((results) => {
     results.forEach((result) => {
-      core.info(`foreach: ${result}`)
-      core.info(`foreach: ${JSON.stringify(result)}`)
+      if (result?.value) {
+        collaborators.push(result?.value);
+      }
     });
   });
 
-  core.info(`Filtered list of collabs ${collaborator_responses.join(', ')}`);
-
+  // Only include aliases and teams that exist as collaborators
+  const filtered_reviewers = reviewers.filter((reviewer) => collaborators.includes(reviewer));
+  core.info(`Filtered list of only collaborators ${filtered_reviewers.join(', ')}`);
   return [ ];
 }
 

--- a/src/github.js
+++ b/src/github.js
@@ -170,32 +170,13 @@ async function assign_reviewers(reviewers) {
   const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
   const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
 
-  const request_review_responses = [];
-
-  // Github's requestReviewers API will fail to add all reviewers if any of the aliases are not collaborators.
-  // Github also does not support a batch call to determine which aliases in the list are not collaborators.
-
-  // We therefore make each call individually so that we add all reviewers that are collaborators,
-  // and log failure for aliases that no longer have access.
-  teams.forEach((team) => {
-    request_review_responses.push(octokit.pulls.requestReviewers({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      pull_number: context.payload.pull_request.number,
-      team_reviewers: [ team ],
-    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
+  return octokit.pulls.requestReviewers({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number,
+    reviewers: individuals,
+    team_reviewers: teams,
   });
-
-  individuals.forEach((login) => {
-    request_review_responses.push(octokit.pulls.requestReviewers({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      pull_number: context.payload.pull_request.number,
-      reviewers: [ login ],
-    }).catch((error) => core.error(`Individual: ${login} failed to be added with error: ${error}`)));
-  });
-
-  return Promise.allSettled(request_review_responses);
 }
 
 /* Private */

--- a/src/github.js
+++ b/src/github.js
@@ -181,7 +181,7 @@ async function filter_only_collaborators(reviewers) {
     }).then(function(response) {
       core.info(JSON.stringify(response));
       return team;
-    }));
+    }).catch((error) => core.error(`Team: ${team} failed to be added with error: ${error}`)));
   });
 
   individuals.forEach((alias) => {
@@ -192,7 +192,7 @@ async function filter_only_collaborators(reviewers) {
     }).then(function(response) {
       core.info(JSON.stringify(response));
       return alias;
-    }));
+    }).catch((error) => core.error(`Individual: ${alias} failed to be added with error: ${error}`)));
   });
 
   await Promise.allSettled(collaborator_responses);

--- a/src/github.js
+++ b/src/github.js
@@ -212,7 +212,7 @@ async function filter_only_collaborators(reviewers) {
   // Only include aliases and teams that exist as collaborators
   const filtered_reviewers = reviewers.filter((reviewer) => collaborators.includes(reviewer));
   core.info(`Filtered list of only collaborators ${filtered_reviewers.join(', ')}`);
-  return [ ];
+  return filtered_reviewers;
 }
 
 async function assign_reviewers(reviewers) {

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,8 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
-  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
-  reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
+  // core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
+  // reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
 
   core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
   reviewers = github.filter_only_collaborators(reviewers);

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,9 @@ async function run() {
   core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
   reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
 
+  core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
+  reviewers = github.filter_only_collaborators(reviewers);
+
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,8 @@ async function run() {
     reviewers.push(...default_reviewers);
   }
 
-  // core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
-  // reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
+  core.info(`Possible Reviewers ${reviewers.join(', ')}, prepare filtering out already requested reviewers or approved reviewers`);
+  reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
 
   core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
   reviewers = await github.filter_only_collaborators(reviewers);

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ async function run() {
   // reviewers = reviewers.filter((reviewer) => !requested_approved_reviewers.includes(reviewer));
 
   core.info(`Possible New Reviewers ${reviewers.join(', ')}, prepare to filter to only collaborators`);
-  reviewers = github.filter_only_collaborators(reviewers);
+  reviewers = await github.filter_only_collaborators(reviewers);
 
   core.info('Randomly picking reviewers if the number of reviewers is set');
   reviewers = randomly_pick_reviewers({ reviewers, config });

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -279,10 +279,10 @@ describe('github', function() {
   });
 
   describe('assign_reviewers()', function() {
-    const stub = sinon.stub();
+    const spy = sinon.spy();
     const octokit = {
       pulls: {
-        requestReviewers: stub,
+        requestReviewers: spy,
       },
     };
 
@@ -291,144 +291,24 @@ describe('github', function() {
       restoreModule = rewired_github.__set__('octokit_cache', octokit);
     });
     afterEach(function() {
-      stub.reset();
       restoreModule();
     });
 
-    it('assigns reviewers - mixed success', async function() {
-      stub.onFirstCall().resolves({});
-      stub.onSecondCall().resolves({});
-      stub.onThirdCall().resolves({});
-
+    it('assigns reviewers', async function() {
       const reviewers = [ 'mario', 'princess-peach', 'team:koopa-troop' ];
       await rewired_github.assign_reviewers(reviewers);
 
-      expect(stub.calledThrice).to.be.true;
-      expect(stub.firstCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
-        team_reviewers: [
-          'koopa-troop',
-        ],
-      });
-
-      expect(stub.secondCall.args[0]).to.deep.equal({
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.lastCall.args[0]).to.deep.equal({
         owner: 'necojackarc',
         pull_number: 18,
         repo: 'auto-request-review',
         reviewers: [
           'mario',
-        ],
-      });
-
-      expect(stub.thirdCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
-        reviewers: [
           'princess-peach',
         ],
-      });
-    });
-
-    it('assigns reviewers - continues after failure individual', async function() {
-      stub.onFirstCall().resolves({});
-      let isResolved = false;
-      let isRejected = false;
-      const error = new Error('Alias is not a collaborator');
-      const failedNetworkCall = Promise.reject(error).then(
-        function(value) {
-          isResolved = true; return value;
-        },
-        function(error) {
-          isRejected = true; throw error;
-        }
-      );
-      stub.onSecondCall().returns(failedNetworkCall);
-      stub.onThirdCall().resolves({});
-
-      const reviewers = [ 'team:super_marios', 'princess-peach', 'luigi' ];
-      await rewired_github.assign_reviewers(reviewers);
-
-      expect(stub.calledThrice).to.be.true;
-      expect(stub.firstCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
-        team_reviewers: [
-          'super_marios',
-        ],
-      });
-
-      expect(stub.secondCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
-        reviewers: [
-          'princess-peach',
-        ],
-      });
-      expect(isRejected).to.be.true;
-      expect(isResolved).to.be.false;
-
-      expect(stub.thirdCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
-        reviewers: [
-          'luigi',
-        ],
-      });
-    });
-
-    it('assigns reviewers - continues after failure team', async function() {
-      let isResolved = false;
-      let isRejected = false;
-      const error = new Error('Alias is not a collaborator');
-      const failedNetworkCall = Promise.reject(error).then(
-        function(value) {
-          isResolved = true; return value;
-        },
-        function(error) {
-          isRejected = true; throw error;
-        }
-      );
-      stub.onFirstCall().returns(failedNetworkCall);
-      stub.onSecondCall().resolves({});
-      stub.onThirdCall().resolves({});
-
-      const reviewers = [ 'team:toads', 'team:koopa-troop', 'mario' ];
-      await rewired_github.assign_reviewers(reviewers);
-
-      expect(stub.calledThrice).to.be.true;
-
-      expect(stub.firstCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
-        team_reviewers: [
-          'toads',
-        ],
-      });
-      expect(isRejected).to.be.true;
-      expect(isResolved).to.be.false;
-
-      expect(stub.secondCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
         team_reviewers: [
           'koopa-troop',
-        ],
-      });
-
-      expect(stub.thirdCall.args[0]).to.deep.equal({
-        owner: 'necojackarc',
-        pull_number: 18,
-        repo: 'auto-request-review',
-        reviewers: [
-          'mario',
         ],
       });
     });


### PR DESCRIPTION
In a previous PR (https://github.com/Mojang/auto-request-review/pull/5), the `request reviewer` call was converted from a batch call to multiple individual calls in order to support cases where an alias no longer has access to the repo.

In very rare circumstances, it has been reported that the action will actually remove add (and then automatically get removed) from the pull request. Since the action doesn't invoke any `remove reviewer` APIs, the only theory so far is that making multiple edit request simultaneously has exposed a rare syncronous problem, usually when combined with [auto assignment](https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment). This scenario is rare enough that it has been difficult to get reproductions of the issue in test environments.

The proposed solution is to instead async request the permission status of every alias the action will attempt to add. After locally filtering out all aliases that do not have permissions, make a batch request with all of the remaining aliases. This adds 1 extra network call compared to the solution in 5, but reduces the number of network calls attempting to edit the PR down to 1.