### PR TITLE
Add Reviewer Alias Validation to the Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,6 @@ If the action is re-run post an administrator giving access to the aliases, or t
 from the config yaml file, the action will update the comment to notify that all issues have been resolved.
 
 ```
-All alias issues have been resolved!
+All reviewer issues have been resolved!
 Comment added by Auto Reviewer Robot 🤖: <Base64 Unique ID>
 ```

--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ jobs:
           # This defaults to false if not specified.
           # See https://github.com/necojackarc/auto-request-review/issues/76 for more details.
           use_local: true
+          # Validates that all reviewers inside the config file (e.g. .github/reviewers.yml specified
+          # above) have access to be added as reviewers to the repository running this yaml. This
+          # can be used similar to native CODEOWNER errors reported by github: 
+          # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-codeowners-errors
+          #
+          # This defaults to false if not specified.
+          validate_all: true
 ```
 
 ### (Optional) GitHub Personal Access Token
@@ -248,3 +255,30 @@ on:
 #### Dependabot compatibility
 
 Note that with the [recent change to GitHub Actions that are created by Dependabot](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/), the `pull_request` event will no longer give access to your secrets to this action. Instead you will need to use the `pull_request_target` event. If you do this make sure to read [Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) to understand the risks involved.
+
+## Reviewer Access and Private Repos
+
+The reviewer aliases defined in the configurations must have been given access to the repo in order to
+be added as a code reviewer to the pull request. 
+
+If the action attempts to assign a reviewer that does not have access to the repo, a comment will be
+automatically addded to the pull request to notify the author that not everyone was assigned.
+```
+The following reviewers did not have access to be added as reviewers, please review their access:
+
+Individual Alias
+    - jamoor-test-twice
+
+Team Alias
+    - fake-team-super-stale
+
+Comment added by Auto Reviewer Robot 🤖: <Base64 Unique ID>
+```
+
+If the action is re-run post an administrator giving access to the aliases, or the aliases are removed
+from the config yaml file, the action will update the comment to notify that all issues have been resolved.
+
+```
+All alias issues have been resolved!
+Comment added by Auto Reviewer Robot 🤖: <Base64 Unique ID>
+```

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   use_local:
     required: false
     default: 'false'
+  validate_all:
+    required: false
+    default: 'false'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -17589,7 +17589,7 @@ async function assign_reviewers(reviewers) {
   });
 }
 
-function getCommentFooter() {
+function get_comment_footer() {
   // Returns a unique to the pull request id used to identify the action's comment
   const context = get_context();
   const commentKey = Buffer.from(`${context.repo.repo}-${context.payload.pull_request.number}`).toString('base64');
@@ -17606,7 +17606,7 @@ async function get_existing_comment() {
     issue_number: context.payload.pull_request.number,
   });
 
-  const robotFooter = getCommentFooter();
+  const robotFooter = get_comment_footer();
   const commentList = response?.data || [];
 
   // Search for a comment with our footer. If more that one exists, select the first
@@ -17639,7 +17639,7 @@ function get_missing_access_message(reviewers) {
     });
   }
 
-  message += `\n${getCommentFooter()}`;
+  message += `\n${get_comment_footer()}`;
 
   return message;
 }
@@ -17651,7 +17651,7 @@ async function post_notification(reviewers, comment) {
   if (reviewers.length) {
     // If we have a list of reviewers without access, prepare a message
     // with the reviewers.
-    const message = get_missing_access_message();
+    const message = get_missing_access_message(reviewers);
 
     // If the action has already created a comment, only update the comment
     // if the list of reviewers has changed.
@@ -17682,7 +17682,7 @@ async function post_notification(reviewers, comment) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       comment_id: comment?.id,
-      body: `All reviewer issues have been resolved!\n${getCommentFooter()}`,
+      body: `All reviewer issues have been resolved!\n${get_comment_footer()}`,
     });
   }
 }
@@ -17735,9 +17735,12 @@ module.exports = {
   fetch_config,
   fetch_changed_files,
   fetch_reviewers,
+  split_reviewers,
   filter_only_collaborators,
   assign_reviewers,
+  get_comment_footer,
   get_existing_comment,
+  get_missing_access_message,
   post_notification,
   clear_cache,
 };
@@ -17769,6 +17772,10 @@ const {
 let validate_all_reviewers_cache;
 function get_validate_all_reviewers() {
   return validate_all_reviewers_cache ?? (validate_all_reviewers_cache = core.getInput('validate_all') === 'true');
+}
+
+function clear_cache() {
+  validate_all_reviewers_cache = undefined;
 }
 
 async function run() {
@@ -17874,6 +17881,7 @@ async function run() {
 }
 
 module.exports = {
+  clear_cache,
   run,
 };
 

--- a/src/github.js
+++ b/src/github.js
@@ -240,7 +240,7 @@ async function assign_reviewers(reviewers) {
   });
 }
 
-function getCommentFooter() {
+function get_comment_footer() {
   // Returns a unique to the pull request id used to identify the action's comment
   const context = get_context();
   const commentKey = Buffer.from(`${context.repo.repo}-${context.payload.pull_request.number}`).toString('base64');
@@ -257,7 +257,7 @@ async function get_existing_comment() {
     issue_number: context.payload.pull_request.number,
   });
 
-  const robotFooter = getCommentFooter();
+  const robotFooter = get_comment_footer();
   const commentList = response?.data || [];
 
   // Search for a comment with our footer. If more that one exists, select the first
@@ -290,7 +290,7 @@ function get_missing_access_message(reviewers) {
     });
   }
 
-  message += `\n${getCommentFooter()}`;
+  message += `\n${get_comment_footer()}`;
 
   return message;
 }
@@ -302,7 +302,7 @@ async function post_notification(reviewers, comment) {
   if (reviewers.length) {
     // If we have a list of reviewers without access, prepare a message
     // with the reviewers.
-    const message = get_missing_access_message();
+    const message = get_missing_access_message(reviewers);
 
     // If the action has already created a comment, only update the comment
     // if the list of reviewers has changed.
@@ -333,7 +333,7 @@ async function post_notification(reviewers, comment) {
       owner: context.repo.owner,
       repo: context.repo.repo,
       comment_id: comment?.id,
-      body: `All reviewer issues have been resolved!\n${getCommentFooter()}`,
+      body: `All reviewer issues have been resolved!\n${get_comment_footer()}`,
     });
   }
 }
@@ -386,9 +386,12 @@ module.exports = {
   fetch_config,
   fetch_changed_files,
   fetch_reviewers,
+  split_reviewers,
   filter_only_collaborators,
   assign_reviewers,
+  get_comment_footer,
   get_existing_comment,
+  get_missing_access_message,
   post_notification,
   clear_cache,
 };

--- a/src/github.js
+++ b/src/github.js
@@ -260,7 +260,7 @@ async function get_existing_comment() {
   const robotFooter = getCommentFooter();
   const commentList = response?.data || [];
 
-  // Search for a comment with our footer. If more that one exists, select the first 
+  // Search for a comment with our footer. If more that one exists, select the first
   // one returned but log an error for debugging (includes links to each matched comment)
   const robotComments = commentList.filter((comment) => (comment.body ?? '').includes(robotFooter));
   if (robotComments.length > 1) {
@@ -302,7 +302,7 @@ async function post_notification(reviewers, comment) {
   if (reviewers.length) {
     // If we have a list of reviewers without access, prepare a message
     // with the reviewers.
-    let message = get_missing_access_message();
+    const message = get_missing_access_message();
 
     // If the action has already created a comment, only update the comment
     // if the list of reviewers has changed.

--- a/src/github.js
+++ b/src/github.js
@@ -163,12 +163,19 @@ async function fetch_reviewers() {
   return [ ...reviewers ];
 }
 
+function split_reviewers(reviewers) {
+  // Splits the list of reviewers into a list of individual aliases and a list of team aliases (team prefix removed)
+  const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
+  const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
+
+  return [ individuals, teams ];
+}
+
 async function filter_only_collaborators(reviewers) {
   const context = get_context();
   const octokit = get_octokit();
 
-  const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
-  const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
+  const [ individuals, teams ] = split_reviewers(reviewers);
 
   // Create a list of requests for all available aliases and teams to see if they have permission
   // to the PR associated with this action
@@ -209,18 +216,20 @@ async function filter_only_collaborators(reviewers) {
     });
   });
 
-  // Only include aliases and teams that exist as collaborators
+  // Create two lists to notify the caller about the reviewer level of access
+  // 1) Only include aliases and teams that exist as collaborators
+  // 2) Only includes aliases that failed to pass the permission check
   const filtered_reviewers = reviewers.filter((reviewer) => collaborators.includes(reviewer));
+  const no_access_reviewers = reviewers.filter((reviewer) => !collaborators.includes(reviewer));
   core.info(`Filtered list of only collaborators ${filtered_reviewers.join(', ')}`);
-  return filtered_reviewers;
+  return [ filtered_reviewers, no_access_reviewers ];
 }
 
 async function assign_reviewers(reviewers) {
   const context = get_context();
   const octokit = get_octokit();
 
-  const [ teams_with_prefix, individuals ] = partition(reviewers, (reviewer) => reviewer.startsWith('team:'));
-  const teams = teams_with_prefix.map((team_with_prefix) => team_with_prefix.replace('team:', ''));
+  const [ individuals, teams ] = split_reviewers(reviewers);
 
   return octokit.pulls.requestReviewers({
     owner: context.repo.owner,
@@ -229,6 +238,104 @@ async function assign_reviewers(reviewers) {
     reviewers: individuals,
     team_reviewers: teams,
   });
+}
+
+function getCommentFooter() {
+  // Returns a unique to the pull request id used to identify the action's comment
+  const context = get_context();
+  const commentKey = Buffer.from(`${context.repo.repo}-${context.payload.pull_request.number}`).toString('base64');
+  return `Comment added by Auto Reviewer Robot 🤖: ${commentKey}`;
+}
+
+async function get_existing_comment() {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  const response = await octokit.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.payload.pull_request.number,
+  });
+
+  const robotFooter = getCommentFooter();
+  const commentList = response?.data || [];
+
+  // Search for a comment with our footer. If more that one exists, select the first 
+  // one returned but log an error for debugging (includes links to each matched comment)
+  const robotComments = commentList.filter((comment) => (comment.body ?? '').includes(robotFooter));
+  if (robotComments.length > 1) {
+    const commentsInfo = robotComments.map((comment) => comment.html_url);
+    core.error(`Found more than one comment from the action. picking the first: ${JSON.stringify(commentsInfo)}`);
+  }
+
+  return robotComments.shift();
+}
+
+function get_missing_access_message(reviewers) {
+  let message = 'The following reviewers did not have access to be added as reviewers, please review their access:\n';
+
+  // Split aliases based on team vs individual
+  const [ individuals, teams ] = split_reviewers(reviewers);
+  if (individuals.length) {
+    message += '### *Individual Alias*\n';
+    individuals.forEach((alias) => {
+      message += `- ${alias}\n`;
+    });
+  }
+
+  if (teams.length) {
+    message += '### *Team Alias*\n';
+    teams.forEach((alias) => {
+      message += `- ${alias}\n`;
+    });
+  }
+
+  message += `\n${getCommentFooter()}`;
+
+  return message;
+}
+
+async function post_notification(reviewers, comment) {
+  const context = get_context();
+  const octokit = get_octokit();
+
+  if (reviewers.length) {
+    // If we have a list of reviewers without access, prepare a message
+    // with the reviewers.
+    let message = get_missing_access_message();
+
+    // If the action has already created a comment, only update the comment
+    // if the list of reviewers has changed.
+    if (comment?.id) {
+      if (message.localeCompare(comment?.body)) {
+        await octokit.issues.updateComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          comment_id: comment?.id,
+          body: message,
+        });
+      }
+
+      return;
+    }
+
+    // If there exists no comment, create one.
+    await octokit.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.payload.pull_request.number,
+      body: message,
+    });
+  } else if (comment?.id) {
+    // If we no longer have any access issues with our aliases but we have
+    // commented before, lets notify the author that all issues are fixed.
+    await octokit.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: comment?.id,
+      body: `All reviewer issues have been resolved!\n${getCommentFooter()}`,
+    });
+  }
 }
 
 /* Private */
@@ -281,5 +388,7 @@ module.exports = {
   fetch_reviewers,
   filter_only_collaborators,
   assign_reviewers,
+  get_existing_comment,
+  post_notification,
   clear_cache,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,10 @@ function get_validate_all_reviewers() {
   return validate_all_reviewers_cache ?? (validate_all_reviewers_cache = core.getInput('validate_all') === 'true');
 }
 
+function clear_cache() {
+  validate_all_reviewers_cache = undefined;
+}
+
 async function run() {
   core.info('Fetching configuration file from the source branch');
 
@@ -123,6 +127,7 @@ async function run() {
 }
 
 module.exports = {
+  clear_cache,
   run,
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ async function run() {
     core.info('No new reviewers to assign to PR');
   }
 
-  // If we either have reviewers without access OR this action has previously created a comment, 
+  // If we either have reviewers without access OR this action has previously created a comment,
   // trigger updating our comment with the latest information.
   const existing_comment = await github.get_existing_comment();
   if (aliases_missing_access.length > 0 || existing_comment) {

--- a/src/reviewer.js
+++ b/src/reviewer.js
@@ -136,6 +136,17 @@ function randomly_pick_reviewers({ reviewers, config }) {
   return sample_size(reviewers, number_of_reviewers);
 }
 
+function fetch_all_reviewers(config) {
+  // Pulls all potential reviewers (defaults, based on author, based on files)
+  const default_reviewers = config?.reviewers?.defaults ?? [];
+  const reviewers_based_on_author = Object.values(config?.reviewers?.per_author ?? {}).flat();
+  const reviewers_based_on_files = Object.values(config?.files ?? {}).flat();
+
+  // Replaces the group names with real reviewers
+  const reviewers = [ ...default_reviewers, ...reviewers_based_on_author, ...reviewers_based_on_files ];
+  return [ ...new Set(replace_groups_with_individuals({ reviewers: reviewers, config })) ];
+}
+
 /* Private */
 
 function replace_groups_with_individuals({ reviewers, config }) {
@@ -152,4 +163,5 @@ module.exports = {
   should_request_review,
   fetch_default_reviewers,
   randomly_pick_reviewers,
+  fetch_all_reviewers,
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,31 +1,41 @@
 'use strict';
 
+const core = require('@actions/core');
 const github = require('../src/github');
 const sinon = require('sinon');
 const { expect } = require('chai');
 
-const { run } = require('../src/index');
+const { run, clear_cache } = require('../src/index');
 
 describe('index', function() {
   describe('run()', function() {
     beforeEach(function() {
+      clear_cache();
       github.clear_cache();
 
-      sinon.stub(github, 'get_pull_request');
       sinon.stub(github, 'fetch_config');
+      sinon.stub(github, 'get_pull_request');
       sinon.stub(github, 'fetch_changed_files');
       sinon.stub(github, 'fetch_reviewers');
       sinon.stub(github, 'filter_only_collaborators');
       sinon.stub(github, 'assign_reviewers');
+      sinon.stub(github, 'get_existing_comment');
+      sinon.stub(github, 'post_notification');
+
+      sinon.stub(core, 'getInput');
     });
 
     afterEach(function() {
-      github.get_pull_request.restore();
       github.fetch_config.restore();
+      github.get_pull_request.restore();
       github.fetch_changed_files.restore();
       github.fetch_reviewers.restore();
       github.filter_only_collaborators.restore();
       github.assign_reviewers.restore();
+      github.get_existing_comment.restore();
+      github.post_notification.restore();
+
+      core.getInput.restore();
     });
 
     it('requests review based on files changed', async function() {
@@ -50,18 +60,25 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [ 'path/to/file.js' ];
-      github.fetch_changed_files.returns(changed_fiels);
+      const changed_files = [ 'path/to/file.js' ];
+      github.fetch_changed_files.returns(changed_files);
 
       const current_reviewers = [];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'mario', 'princess-peach' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario', 'princess-peach' ]);
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('skips single alias if already a reviewer', async function() {
@@ -92,12 +109,19 @@ describe('index', function() {
       const current_reviewers = [ 'princess-peach' ];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'mario' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario' ]);
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('skips team alias if already a reviewer', async function() {
@@ -128,12 +152,19 @@ describe('index', function() {
       const current_reviewers = [ 'team:bowser-and-co' ];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'mario', 'team:peach-alliance', 'wario', 'waluigi' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario', 'team:peach-alliance', 'wario', 'waluigi' ]);
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('skips calling assign if no reviewers', async function() {
@@ -164,11 +195,18 @@ describe('index', function() {
       const current_reviewers = [ 'princess-peach', 'mario' ];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
-      expect(github.assign_reviewers.calledOnce).to.be.false;
+      expect(github.assign_reviewers.notCalled).to.be.true;
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('removes non collaborators - individual', async function() {
@@ -200,15 +238,24 @@ describe('index', function() {
       github.fetch_reviewers.returns(current_reviewers);
 
       const collaborators = [ 'mario' ];
-      github.filter_only_collaborators.returns(collaborators);
+      const missing_access = [ 'princess-peach' ];
+      github.filter_only_collaborators.returns([ collaborators, missing_access ]);
+
+      const comment = { id: 123, body: 'test comment' };
+      github.get_existing_comment.returns(comment);
 
       await run();
+
+      expect(github.assign_reviewers.calledOnce).to.be.true;
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
 
       expect(github.filter_only_collaborators.calledOnce).to.be.true;
       expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members([ 'mario', 'princess-peach' ]);
 
-      expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario' ]);
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.calledOnce).to.be.true;
+      expect(github.post_notification.lastCall.args[0]).to.have.members(missing_access);
+      expect(github.post_notification.lastCall.args[1]).to.deep.equal(comment);
     });
 
     it('removes non collaborators - team', async function() {
@@ -240,15 +287,24 @@ describe('index', function() {
       github.fetch_reviewers.returns(current_reviewers);
 
       const collaborators = [ 'team:peach-alliance' ];
-      github.filter_only_collaborators.returns(collaborators);
+      const missing_access = [ 'mario', 'wario', 'waluigi', 'team:bowser-and-co' ];
+      github.filter_only_collaborators.returns([ collaborators, missing_access ]);
+
+      const comment = { id: 123, body: 'test comment' };
+      github.get_existing_comment.returns(comment);
 
       await run();
+
+      expect(github.assign_reviewers.calledOnce).to.be.true;
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'team:peach-alliance' ]);
 
       expect(github.filter_only_collaborators.calledOnce).to.be.true;
       expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members([ 'mario', 'team:peach-alliance', 'wario', 'waluigi', 'team:bowser-and-co' ]);
 
-      expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'team:peach-alliance' ]);
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.calledOnce).to.be.true;
+      expect(github.post_notification.lastCall.args[0]).to.have.members(missing_access);
+      expect(github.post_notification.lastCall.args[1]).to.deep.equal(comment);
     });
 
     it('removes non collaborators + previous review mix', async function() {
@@ -280,15 +336,24 @@ describe('index', function() {
       github.fetch_reviewers.returns(current_reviewers);
 
       const collaborators = [ 'mario', 'team:bowser-and-co' ];
-      github.filter_only_collaborators.returns(collaborators);
+      const missing_access = [ 'wario' ];
+      github.filter_only_collaborators.returns([ collaborators, missing_access ]);
+
+      const comment = { id: 123, body: 'test comment' };
+      github.get_existing_comment.returns(comment);
 
       await run();
+
+      expect(github.assign_reviewers.calledOnce).to.be.true;
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
 
       expect(github.filter_only_collaborators.calledOnce).to.be.true;
       expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members([ 'mario', 'wario', 'team:bowser-and-co' ]);
 
-      expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario', 'team:bowser-and-co' ]);
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.calledOnce).to.be.true;
+      expect(github.post_notification.lastCall.args[0]).to.have.members(missing_access);
+      expect(github.post_notification.lastCall.args[1]).to.deep.equal(comment);
     });
 
     it('requests review based on groups that author belongs to', async function() {
@@ -313,18 +378,25 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [];
-      github.fetch_changed_files.returns(changed_fiels);
+      const changed_files = [];
+      github.fetch_changed_files.returns(changed_files);
 
       const current_reviewers = [];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'mario', 'dr-mario' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario', 'dr-mario' ]);
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('does not request review with "ignore_draft" true if a pull request is a draft', async function() {
@@ -345,15 +417,14 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [ 'path/to/file.js' ];
-      github.fetch_changed_files.returns(changed_fiels);
-
-      const current_reviewers = [];
-      github.fetch_reviewers.returns(current_reviewers);
-
       await run();
 
-      expect(github.assign_reviewers.calledOnce).to.be.false;
+      expect(github.fetch_changed_files.notCalled).to.be.true;
+      expect(github.fetch_reviewers.notCalled).to.be.true;
+      expect(github.filter_only_collaborators.notCalled).to.be.true;
+      expect(github.assign_reviewers.notCalled).to.be.true;
+      expect(github.get_existing_comment.notCalled).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('does not request review if a pull request title contains any of "ignored_keywords"', async function() {
@@ -374,17 +445,14 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [ 'path/to/file.js' ];
-      github.fetch_changed_files.returns(changed_fiels);
-
-      const current_reviewers = [];
-      github.fetch_reviewers.returns(current_reviewers);
-
-      github.filter_only_collaborators.returnsArg(0);
-
       await run();
 
-      expect(github.assign_reviewers.calledOnce).to.be.false;
+      expect(github.fetch_changed_files.notCalled).to.be.true;
+      expect(github.fetch_reviewers.notCalled).to.be.true;
+      expect(github.filter_only_collaborators.notCalled).to.be.true;
+      expect(github.assign_reviewers.notCalled).to.be.true;
+      expect(github.get_existing_comment.notCalled).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('does not request review if no reviewers are matched and default reviweres are not set', async function() {
@@ -408,17 +476,21 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [ 'path/to/file.py' ];
-      github.fetch_changed_files.returns(changed_fiels);
+      const changed_files = [ 'path/to/file.py' ];
+      github.fetch_changed_files.returns(changed_files);
 
       const current_reviewers = [];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
-      expect(github.assign_reviewers.calledOnce).to.be.false;
+      expect(github.filter_only_collaborators.notCalled).to.be.true;
+      expect(github.assign_reviewers.notCalled).to.be.true;
+      expect(github.get_existing_comment.notCalled).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('requests review to the default reviewers if no reviewers are matched', async function() {
@@ -443,18 +515,25 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [ 'path/to/file.py' ];
-      github.fetch_changed_files.returns(changed_fiels);
+      const changed_files = [ 'path/to/file.py' ];
+      github.fetch_changed_files.returns(changed_files);
 
       const current_reviewers = [];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'dr-mario', 'mario' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'dr-mario', 'mario' ]);
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('requests review based on reviewers per author', async function() {
@@ -479,18 +558,25 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [];
-      github.fetch_changed_files.returns(changed_fiels);
+      const changed_files = [];
+      github.fetch_changed_files.returns(changed_files);
 
       const current_reviewers = [];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'mario', 'waluigi' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario', 'waluigi' ]);
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('requests review based on reviewers per author when a group is used as an auther setting', async function() {
@@ -515,18 +601,25 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [];
-      github.fetch_changed_files.returns(changed_fiels);
+      const changed_files = [];
+      github.fetch_changed_files.returns(changed_files);
 
       const current_reviewers = [];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'mario', 'dr-mario', 'waluigi' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-      expect(github.assign_reviewers.lastCall.args[0]).to.have.members([ 'mario', 'dr-mario', 'waluigi' ]);
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
     });
 
     it('limits the number of reviewers based on number_of_reviewers setting', async function() {
@@ -549,21 +642,268 @@ describe('index', function() {
       };
       github.get_pull_request.returns(pull_request);
 
-      const changed_fiels = [];
-      github.fetch_changed_files.returns(changed_fiels);
+      const changed_files = [];
+      github.fetch_changed_files.returns(changed_files);
 
       const current_reviewers = [];
       github.fetch_reviewers.returns(current_reviewers);
 
-      github.filter_only_collaborators.returnsArg(0);
+      const collaborators = [ 'dr-mario', 'mario', 'waluigi' ];
+      github.filter_only_collaborators.returns([ collaborators, [] ]);
 
       await run();
 
       expect(github.assign_reviewers.calledOnce).to.be.true;
-
       const randomly_picked_reviewers = github.assign_reviewers.lastCall.args[0];
       expect([ 'dr-mario', 'mario', 'waluigi' ]).to.include.members(randomly_picked_reviewers);
       expect(new Set(randomly_picked_reviewers)).to.have.lengthOf(2);
+
+      expect(github.filter_only_collaborators.calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
+    });
+
+    it('Validate Mode - Adds To Non Collaborators', async function() {
+      core.getInput.withArgs('validate_all').returns('true');
+
+      const config = {
+        reviewers: {
+          defaults: [ 'dr-mario' ],
+          groups: {
+            'mario-brothers': [ 'mario', 'luigi' ],
+          },
+        },
+        files: {
+          '**/*.js': [ 'mario-brothers', 'team:peach-alliance' ],
+          '**/*.rb': [ 'wario', 'waluigi', 'team:bowser-and-co' ],
+        },
+      };
+      github.fetch_config.returns(config);
+
+      const pull_request = {
+        title: 'Nice Pull Request',
+        is_draft: false,
+        author: 'luigi',
+      };
+      github.get_pull_request.returns(pull_request);
+
+      const changed_files = [ 'path/to/file.rb' ];
+      github.fetch_changed_files.returns(changed_files);
+
+      const current_reviewers = [ ];
+      github.fetch_reviewers.returns(current_reviewers);
+
+      // Initial filter from the file.rb file change
+      const first_filter_args = [ 'wario', 'waluigi', 'team:bowser-and-co' ];
+      const collaborators = [ 'waluigi', 'team:bowser-and-co' ];
+      const missing_access = [ 'wario' ];
+      github.filter_only_collaborators.withArgs(first_filter_args).returns([ collaborators, missing_access ]);
+
+      // Second filter after validate all has been called
+      const second_filter_args = [ 'dr-mario', 'mario', 'luigi', 'team:peach-alliance' ];
+      const collaborators_second = [ 'dr-mario', 'luigi', 'team:peach-alliance' ];
+      const missing_access_second = [ 'mario' ];
+      github.filter_only_collaborators.withArgs(second_filter_args).returns([ collaborators_second, missing_access_second ]);
+
+      const comment = { id: 123, body: 'test comment' };
+      github.get_existing_comment.returns(comment);
+
+      await run();
+
+      expect(github.assign_reviewers.calledOnce).to.be.true;
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(core.getInput.withArgs('validate_all').calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.calledTwice).to.be.true;
+      expect(github.filter_only_collaborators.firstCall.args[0]).to.have.members(first_filter_args);
+      expect(github.filter_only_collaborators.secondCall.args[0]).to.have.members(second_filter_args);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.calledOnce).to.be.true;
+      expect(github.post_notification.lastCall.args[0]).to.have.members([ ...missing_access, ...missing_access_second ]);
+      expect(github.post_notification.lastCall.args[1]).to.deep.equal(comment);
+    });
+
+    it('Validate Mode - Posts without original missing access', async function() {
+      core.getInput.withArgs('validate_all').returns('true');
+
+      const config = {
+        reviewers: {
+          defaults: [ 'dr-mario' ],
+          groups: {
+            'mario-brothers': [ 'mario', 'luigi' ],
+          },
+        },
+        files: {
+          '**/*.js': [ 'mario-brothers', 'team:peach-alliance' ],
+          '**/*.rb': [ 'wario', 'waluigi', 'team:bowser-and-co' ],
+        },
+      };
+      github.fetch_config.returns(config);
+
+      const pull_request = {
+        title: 'Nice Pull Request',
+        is_draft: false,
+        author: 'luigi',
+      };
+      github.get_pull_request.returns(pull_request);
+
+      const changed_files = [ 'path/to/file.rb' ];
+      github.fetch_changed_files.returns(changed_files);
+
+      const current_reviewers = [ ];
+      github.fetch_reviewers.returns(current_reviewers);
+
+      // Initial filter from the file.rb file change
+      const first_filter_args = [ 'wario', 'waluigi', 'team:bowser-and-co' ];
+      const collaborators = [ 'wario', 'waluigi', 'team:bowser-and-co' ];
+      const missing_access = [ ];
+      github.filter_only_collaborators.withArgs(first_filter_args).returns([ collaborators, missing_access ]);
+
+      // Second filter after validate all has been called
+      const second_filter_args = [ 'dr-mario', 'mario', 'luigi', 'team:peach-alliance' ];
+      const collaborators_second = [ 'dr-mario', 'luigi', 'team:peach-alliance' ];
+      const missing_access_second = [ 'mario' ];
+      github.filter_only_collaborators.withArgs(second_filter_args).returns([ collaborators_second, missing_access_second ]);
+
+      const comment = { id: 123, body: 'test comment' };
+      github.get_existing_comment.returns(comment);
+
+      await run();
+
+      expect(github.assign_reviewers.calledOnce).to.be.true;
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(core.getInput.withArgs('validate_all').calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.calledTwice).to.be.true;
+      expect(github.filter_only_collaborators.firstCall.args[0]).to.have.members(first_filter_args);
+      expect(github.filter_only_collaborators.secondCall.args[0]).to.have.members(second_filter_args);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.calledOnce).to.be.true;
+      expect(github.post_notification.lastCall.args[0]).to.have.members(missing_access_second);
+      expect(github.post_notification.lastCall.args[1]).to.deep.equal(comment);
+    });
+
+    it('Validate Mode - Good State - No Comment', async function() {
+      core.getInput.withArgs('validate_all').returns('true');
+
+      const config = {
+        reviewers: {
+          defaults: [ 'dr-mario' ],
+          groups: {
+            'mario-brothers': [ 'mario', 'luigi' ],
+          },
+        },
+        files: {
+          '**/*.js': [ 'mario-brothers', 'team:peach-alliance' ],
+          '**/*.rb': [ 'wario', 'waluigi', 'team:bowser-and-co' ],
+        },
+      };
+      github.fetch_config.returns(config);
+
+      const pull_request = {
+        title: 'Nice Pull Request',
+        is_draft: false,
+        author: 'luigi',
+      };
+      github.get_pull_request.returns(pull_request);
+
+      const changed_files = [ 'path/to/file.rb' ];
+      github.fetch_changed_files.returns(changed_files);
+
+      const current_reviewers = [ ];
+      github.fetch_reviewers.returns(current_reviewers);
+
+      // Initial filter from the file.rb file change
+      const first_filter_args = [ 'wario', 'waluigi', 'team:bowser-and-co' ];
+      const collaborators = [ 'wario', 'waluigi', 'team:bowser-and-co' ];
+      const missing_access = [ ];
+      github.filter_only_collaborators.withArgs(first_filter_args).returns([ collaborators, missing_access ]);
+
+      // Second filter after validate all has been called
+      const second_filter_args = [ 'dr-mario', 'mario', 'luigi', 'team:peach-alliance' ];
+      const collaborators_second = [ 'dr-mario', 'mario', 'luigi', 'team:peach-alliance' ];
+      const missing_access_second = [ ];
+      github.filter_only_collaborators.withArgs(second_filter_args).returns([ collaborators_second, missing_access_second ]);
+
+      github.get_existing_comment.returns(undefined);
+
+      await run();
+
+      expect(github.assign_reviewers.calledOnce).to.be.true;
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(core.getInput.withArgs('validate_all').calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.calledTwice).to.be.true;
+      expect(github.filter_only_collaborators.firstCall.args[0]).to.have.members(first_filter_args);
+      expect(github.filter_only_collaborators.secondCall.args[0]).to.have.members(second_filter_args);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.notCalled).to.be.true;
+    });
+
+    it('Validate Mode - Good State - Comment', async function() {
+      core.getInput.withArgs('validate_all').returns('true');
+
+      const config = {
+        reviewers: {
+          defaults: [ 'dr-mario' ],
+          groups: {
+            'mario-brothers': [ 'mario', 'luigi' ],
+          },
+        },
+        files: {
+          '**/*.js': [ 'mario-brothers', 'team:peach-alliance' ],
+          '**/*.rb': [ 'wario', 'waluigi', 'team:bowser-and-co' ],
+        },
+      };
+      github.fetch_config.returns(config);
+
+      const pull_request = {
+        title: 'Nice Pull Request',
+        is_draft: false,
+        author: 'luigi',
+      };
+      github.get_pull_request.returns(pull_request);
+
+      const changed_files = [ 'path/to/file.rb' ];
+      github.fetch_changed_files.returns(changed_files);
+
+      const current_reviewers = [ ];
+      github.fetch_reviewers.returns(current_reviewers);
+
+      // Initial filter from the file.rb file change
+      const first_filter_args = [ 'wario', 'waluigi', 'team:bowser-and-co' ];
+      const collaborators = [ 'wario', 'waluigi', 'team:bowser-and-co' ];
+      const missing_access = [ ];
+      github.filter_only_collaborators.withArgs(first_filter_args).returns([ collaborators, missing_access ]);
+
+      // Second filter after validate all has been called
+      const second_filter_args = [ 'dr-mario', 'mario', 'luigi', 'team:peach-alliance' ];
+      const collaborators_second = [ 'dr-mario', 'mario', 'luigi', 'team:peach-alliance' ];
+      const missing_access_second = [ ];
+      github.filter_only_collaborators.withArgs(second_filter_args).returns([ collaborators_second, missing_access_second ]);
+
+      const comment = { id: 123, body: 'test comment' };
+      github.get_existing_comment.returns(comment);
+
+      await run();
+
+      expect(github.assign_reviewers.calledOnce).to.be.true;
+      expect(github.assign_reviewers.lastCall.args[0]).to.have.members(collaborators);
+
+      expect(core.getInput.withArgs('validate_all').calledOnce).to.be.true;
+      expect(github.filter_only_collaborators.calledTwice).to.be.true;
+      expect(github.filter_only_collaborators.firstCall.args[0]).to.have.members(first_filter_args);
+      expect(github.filter_only_collaborators.secondCall.args[0]).to.have.members(second_filter_args);
+
+      expect(github.get_existing_comment.calledOnce).to.be.true;
+      expect(github.post_notification.calledOnce).to.be.true;
+      expect(github.post_notification.lastCall.args[0]).to.have.members([]);
+      expect(github.post_notification.lastCall.args[1]).to.deep.equal(comment);
     });
   });
 });

--- a/test/reviewer.test.js
+++ b/test/reviewer.test.js
@@ -7,6 +7,7 @@ const {
   should_request_review,
   fetch_default_reviewers,
   randomly_pick_reviewers,
+  fetch_all_reviewers,
 } = require('../src/reviewer');
 const { expect } = require('chai');
 
@@ -359,6 +360,83 @@ describe('reviewer', function() {
         },
       };
       expect(randomly_pick_reviewers({ reviewers, config })).to.have.members([ 'dr-mario', 'mario', 'luigi' ]);
+    });
+  });
+
+  describe('fetch_all_reviewers()', function() {
+    it('fetches the default reviewers', function() {
+      const config = {
+        reviewers: {
+          defaults: [ 'dr-mario', 'mario-brothers' ],
+          groups: {
+            'mario-brothers': [ 'mario', 'luigi' ],
+          },
+        },
+      };
+      expect(fetch_all_reviewers(config)).to.have.members([ 'dr-mario', 'mario', 'luigi' ]);
+    });
+
+    it('fetches the per author reviewers', function() {
+      const config = {
+        reviewers: {
+          groups: {
+            engineers: [ 'mario', 'luigi', 'wario', 'waluigi' ],
+            designers: [ 'mario', 'princess-peach', 'princess-daisy' ],
+          },
+          per_author: {
+            engineers: [ 'engineers', 'dr-mario' ],
+            designers: [ 'designers' ],
+            yoshi: [ 'mario', 'luige' ],
+          },
+        },
+      };
+      expect(fetch_all_reviewers(config)).to.have.members([ 'mario', 'luigi', 'wario', 'waluigi', 'dr-mario', 'princess-peach', 'princess-daisy', 'luige' ]);
+    });
+
+    it('fetches the files reviewers', function() {
+      const config = {
+        reviewers: {
+          groups: {
+            'backend-engineers': [ 'mario', 'luigi', 'wario', 'waluigi' ],
+            'frontend-engineers': [ 'princess-peach' ],
+          },
+        },
+        files: {
+          '**/super-star': [ 'mario', 'luigi' ],
+          'backend/**/*': [ 'backend-engineers' ],
+          'backend/**/some-specific-file': [ 'mario', 'someone-specific' ],
+          'frontend/**/*': [ 'frontend-engineers', 'toad' ],
+        },
+      };
+      expect(fetch_all_reviewers(config)).to.have.members([ 'mario', 'luigi', 'wario', 'waluigi', 'someone-specific', 'princess-peach', 'toad' ]);
+    });
+
+    it('fetches all reviewers', function() {
+      const config = {
+        reviewers: {
+          defaults: [ 'dr-mario', 'mario-brothers', 'paper-mario' ],
+          groups: {
+            'mario-brothers': [ 'mario', 'luigi', 'star' ],
+            'engineers': [ 'mario', 'luigi', 'wario', 'waluigi' ],
+            'designers': [ 'mario', 'princess-peach', 'princess-daisy' ],
+            'backend-engineers': [ 'mario', 'luigi', 'wario', 'waluigi' ],
+            'frontend-engineers': [ 'princess-peach' ],
+          },
+          per_author: {
+            engineers: [ 'engineers', 'dr-mario' ],
+            designers: [ 'designers' ],
+            yoshi: [ 'mario', 'luige' ],
+          },
+        },
+        files: {
+          '**/super-star': [ 'mario', 'luigi' ],
+          'backend/**/*': [ 'backend-engineers' ],
+          'backend/**/some-specific-file': [ 'mario', 'someone-specific' ],
+          'frontend/**/*': [ 'frontend-engineers', 'toad' ],
+        },
+      };
+      const expected = [ 'dr-mario', 'mario', 'luigi', 'star', 'paper-mario', 'wario', 'waluigi', 'princess-peach', 'princess-daisy', 'luige', 'someone-specific', 'toad' ];
+      expect(fetch_all_reviewers(config)).to.have.members(expected);
     });
   });
 });


### PR DESCRIPTION
For private repositories that have access to the repository restricted, when a reviewer defined in the yaml configuration file does not have access to the repository, the current action will print out a message in the action that we failed to add that reviewer to the pull request. However, the action "succeeds" and only manually checking the logs lets the PR author know that something went wrong.

The proposal in this change is to help PR authors detect when the aliases that are configured to be added to a PR do not have access. A comment gets created in the pull request with the aliases that do not have access. If the PR author solves this permission problem (either by giving access or removing the alias the config), the action will update the previous comment to notify the user that "All issues have been resolved". Only one comment is added by the action, and that comment will get updated based on the issue during that action run.

An additional parameter (`validate_all`) for the action has been added to allow the above validation to be run on every alias in the yaml configuration. This can be useful for scenarios where the PR author is editing the yaml configuration, and the workflow might want to validate those new alias at PR time instead of waiting until that alias is attempted to use in a subsequent PR and it fails.